### PR TITLE
Add After(ctx, duration) API

### DIFF
--- a/after.go
+++ b/after.go
@@ -1,0 +1,28 @@
+package libtime
+
+import (
+	"context"
+	"time"
+)
+
+// After is a safer, but more expensive alternative to time.After.
+//
+// After waits for the duration to elapse and then sends the current time
+// on the returned channel. If the context gets canceled before the duration
+// elapses, no message is sent on the returned channel.
+//
+// The returned channel is never closed.
+func After(ctx context.Context, duration time.Duration) <-chan time.Time {
+	durationElapsedCh := make(chan time.Time, 1)
+	go func() {
+		t := time.NewTimer(duration)
+		defer t.Stop()
+
+		select {
+		case tick := <-t.C:
+			durationElapsedCh <- tick
+		case <-ctx.Done():
+		}
+	}()
+	return durationElapsedCh
+}

--- a/after_test.go
+++ b/after_test.go
@@ -1,0 +1,29 @@
+package libtime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func Test_After(t *testing.T) {
+	<-After(context.Background(), 3*time.Nanosecond)
+}
+
+func Test_After_canceledCtx(t *testing.T) {
+	const afterTimeout = 1 * time.Millisecond
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	after := After(canceledCtx, afterTimeout)
+
+	afterX2 := time.NewTimer(2 * afterTimeout)
+	defer afterX2.Stop()
+
+	// This test is racy. If it ever fails, consider increasing the multiplier or the timeout, or both
+	select {
+	case <-after:
+		t.Fatal("no messages should be sent on the channel returned by After, if the context is canceled")
+	case <-afterX2.C:
+	}
+}


### PR DESCRIPTION
It is often desirable to track an expiry of some duration
of time in the context of an operation. The standard library
APIs like time.After, time.NewTimer are error-prone and
there are no context-aware variants of these APIs