### PR TITLE
nobug: implement a safe timer function

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,36 @@
+package libtime
+
+import (
+	"time"
+)
+
+// StopFunc is used to stop a time.Timer.
+//
+// Calling StopFunc prevents its time.Timer from firing. Returns true if the call
+// stops the timer, false if the timer has already expired. or has been stopped.
+//
+// https://pkg.go.dev/time#Timer.Stop
+type StopFunc func() bool
+
+// SafeTimer creates a time.Timer and a StopFunc, forcing the caller to deal
+// with the otherwise potential resource leak. Encourages safe use of a time.Timer
+// in a select statement, but without the overhead of a context.Context.
+//
+// Typical usage:
+//
+//    t, stop := libtime.SafeTimer(interval)
+//    defer stop()
+//    for {
+//      select {
+//        case <- t.C:
+//          foo()
+//        case <- otherC :
+//          return
+//      }
+//    }
+//
+// Does not panic if duration is <= 0, instead assuming the smallest positive value.
+func SafeTimer(duration time.Duration) (*time.Timer, StopFunc) {
+	t := time.NewTimer(duration)
+	return t, t.Stop
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,0 +1,20 @@
+package libtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SafeTimer(t *testing.T) {
+	delay := 3 * time.Millisecond
+	start := time.Now()
+
+	timer, stop := SafeTimer(delay)
+	defer stop()
+	<-timer.C
+
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, int64(elapsed), int64(delay))
+}


### PR DESCRIPTION
This PR adds `libtime.SafeTimer` function, which creates a timer that
is more safe to use in select statements, but without the overhead
of creating a `context.Context` object.

Instead it returns a closure over the timer's Stop function, forcing
the caller to deal with stopping the timer. It also avoids panic if
the set duration is <= 0, assuming the [practical] same behavior as
`time.After(0)` - which is to trigger immediately.